### PR TITLE
fix: this should now produce a new image with a major release version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-slim
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
BREAKING CHANGE: this token should work with the semantic release github flow.